### PR TITLE
Add option to print the OZ file tree structure

### DIFF
--- a/oz_tree_build/utilities/generate_filtered_files.py
+++ b/oz_tree_build/utilities/generate_filtered_files.py
@@ -422,7 +422,7 @@ def generate_all_filtered_files(
     filtered_wikidata_dump_file = generate_and_cache_filtered_file(
         wikidata_dump_file, context, generate_filtered_wikidata_dump
     )
-    # filtered_wikipedia_dump_file = generate_and_cache_filtered_file(wikidata_dump_file, context, generate_filtered_wikipedia_dump)
+
     read_wikidata_dump(filtered_wikidata_dump_file, context)
 
     generate_and_cache_filtered_file(


### PR DESCRIPTION
To help make progress on #18, I added an option to print the OZ included file tree when running `build_oz_tree`.

Here is the output. The first number is the length from the parent file, e.g. `CTENOPHORA@:600`. The second number comes from token_to_oz_tree_file_mapping.

```
None: None 0
  DIAPHORETICKES: None 100
  AMORPHEA: None 50
    METAZOA: 150.0 150
      CYCLOSTOMATA: 525.0 43
        LAMPREYS: 332.0 332
      GNATHOSTOMATA: 525.0 65
        COELACANTHIFORMES: None 414
        DIPNOI: None 138
        TETRAPODA: None 75
          PALAEOGNATHAE: 40.45 40.45
            TINAMIFORMES: 16.4 6.85
          NEOGNATHAE: 15.69 15.69
            PASSERIFORMES: 74.7858 8
              GALAPAGOS_FINCHES_AND_ALLIES_: None 3.6
          CROCODYLIA: 152.86 152.86
          TESTUDINES: 55.77 55.77
          MAMMALIA: None 140
            EUTHERIA: None 70
              BOREOEUTHERIA: None 5
                PRIMATES: 70.0 5
                  HYLOBATIDAE: 18.0 12.6
                DERMOPTERA: 70.0 55
              XENARTHRA: None 17.8
              AFROTHERIA: None 4.9
            MARSUPIALIA: None 73
          AMPHIBIA: 30.0 30
        POLYPTERIFORMES: None 353.4
        ACIPENSERIFORMES: None 166.1
        HOLOSTEI: None 54.6
        CHONDRICHTHYES: 460.0 40
          HOLOCEPHALI: None 250
          BATOIDEA: None 100
          SELACHII: 300.0 75
            CARCHARHINICAE_MINUS: 134.467193 134.467193
            SCYLIORHINIDAE2: 134.467193 134.467193
            SCYLIORHINIDAE3: 170.0 170
            DALATIIDAE: 116.1 116.1
            SOMNIOSIDAEOXYNOTIDAE: 110.51 110.51
            ETMOPTERIDAE: 110.51 110.51
            SQUATINIDAE: 147.59 147.59
            PRISTIOPHORIDAE: 147.59 147.59
      AMBULACRARIA: 550.0 20
      PROTOSTOMIA: 560.0 50
      CTENOPHORA: 600.0 50
      PORIFERA: 650.0 50
    HOLOMYCOTA: 1350.0 300
      APHELIDA: 900.0 100
  CRUMS: None None
```