### PR TITLE
Make imports relative

### DIFF
--- a/oz_tree_build/images_and_vernaculars/get_wiki_images.py
+++ b/oz_tree_build/images_and_vernaculars/get_wiki_images.py
@@ -27,16 +27,15 @@ from pathlib import Path
 import requests
 from PIL import Image
 
-from oz_tree_build._OZglobals import src_flags
-from oz_tree_build.images_and_vernaculars import process_image_bits
-from oz_tree_build.utilities.db_helper import (
+from .._OZglobals import src_flags
+from ..utilities.db_helper import (
     connect_to_database,
     get_next_src_id_for_src,
     placeholder,
     read_config,
 )
-from oz_tree_build.utilities.file_utils import enumerate_lines_from_file
-
+from ..utilities.file_utils import enumerate_lines_from_file
+from . import process_image_bits
 from .image_cropping import AzureImageCropper, CenterImageCropper
 
 default_wiki_image_rating = 35000
@@ -411,7 +410,7 @@ def save_wiki_image(db, leaf_data, image_name, src, src_id, rating, output_dir, 
             1,  # These will need to be adjusted based on all images for the taxon
             license_info["artist"],
             license_string,
-            datetime.datetime.now(),
+            datetime.datetime.now().isoformat(),
         ),
     )
     db.commit()
@@ -460,7 +459,7 @@ def save_wiki_vernaculars_for_qid(db, ott, qid, vernaculars_by_language):
                     vernacular["preferred"],
                     src_flags["wiki"],
                     qid,
-                    datetime.datetime.now(),
+                    datetime.datetime.now().isoformat(),
                 ),
             )
 

--- a/oz_tree_build/images_and_vernaculars/process_image_bits.py
+++ b/oz_tree_build/images_and_vernaculars/process_image_bits.py
@@ -1,8 +1,8 @@
 import argparse
 import logging
 
-from oz_tree_build._OZglobals import src_flags
-from oz_tree_build.utilities.db_helper import (
+from .._OZglobals import src_flags
+from ..utilities.db_helper import (
     connect_to_database,
     placeholder,
     read_config,

--- a/oz_tree_build/newick/fix_ultrametricity.py
+++ b/oz_tree_build/newick/fix_ultrametricity.py
@@ -7,7 +7,7 @@ import argparse
 
 import dendropy
 
-from oz_tree_build.newick.check_ultrametricity import get_taxon_name
+from ..newick.check_ultrametricity import get_taxon_name
 
 
 def fix_ultrametricity(tree, expected_length, max_adjustment):

--- a/oz_tree_build/newick/format_newick.py
+++ b/oz_tree_build/newick/format_newick.py
@@ -22,7 +22,7 @@ import argparse
 import re
 import sys
 
-from oz_tree_build.tree_build.build_oz_tree import trim_tree
+from ..tree_build.build_oz_tree import trim_tree
 
 __author__ = "David Ebbo"
 

--- a/oz_tree_build/taxon_mapping_and_popularity/CSV_base_table_creator.py
+++ b/oz_tree_build/taxon_mapping_and_popularity/CSV_base_table_creator.py
@@ -85,9 +85,8 @@ from math import log
 
 from dendropy import Node, Tree
 
-from oz_tree_build.images_and_vernaculars.get_wiki_images import get_qid_from_taxa_data
-from oz_tree_build.utilities.file_utils import open_file_based_on_extension
-
+from ..images_and_vernaculars.get_wiki_images import get_qid_from_taxa_data
+from ..utilities.file_utils import open_file_based_on_extension
 from . import OTT_popularity_mapping
 
 # local packages

--- a/oz_tree_build/taxon_mapping_and_popularity/OTT_popularity_mapping.py
+++ b/oz_tree_build/taxon_mapping_and_popularity/OTT_popularity_mapping.py
@@ -142,8 +142,8 @@ import sys
 from collections import OrderedDict, defaultdict
 from statistics import StatisticsError, mean
 
-from oz_tree_build._OZglobals import wikiflags
-from oz_tree_build.utilities.file_utils import open_file_based_on_extension
+from .._OZglobals import wikiflags
+from ..utilities.file_utils import open_file_based_on_extension
 
 __author__ = "Yan Wong"
 __license__ = """This is free and unencumbered software released into the public domain by the author, Yan Wong, for OneZoom CIO.

--- a/oz_tree_build/tree_build/get_open_trees_from_one_zoom.py
+++ b/oz_tree_build/tree_build/get_open_trees_from_one_zoom.py
@@ -37,8 +37,7 @@ import os
 import sys
 import time
 
-from oz_tree_build.newick.extract_trees import extract_trees
-
+from ..newick.extract_trees import extract_trees
 from .oz_tokens import enumerate_one_zoom_tokens
 
 __author__ = "David Ebbo"

--- a/oz_tree_build/utilities/generate_filtered_files.py
+++ b/oz_tree_build/utilities/generate_filtered_files.py
@@ -14,16 +14,15 @@ import sys
 import time
 from collections import defaultdict
 
-from oz_tree_build._OZglobals import wikiflags
-from oz_tree_build.newick.extract_trees import get_taxon_subtree_from_newick_file
-from oz_tree_build.newick.newick_parser import parse_tree
-from oz_tree_build.taxon_mapping_and_popularity.CSV_base_table_creator import iucn_num
-from oz_tree_build.taxon_mapping_and_popularity.OTT_popularity_mapping import (
+from .._OZglobals import wikiflags
+from ..newick.extract_trees import get_taxon_subtree_from_newick_file
+from ..newick.newick_parser import parse_tree
+from ..taxon_mapping_and_popularity.CSV_base_table_creator import iucn_num
+from ..taxon_mapping_and_popularity.OTT_popularity_mapping import (
     JSON_contains_known_dbID,
     Qid,
     label,
 )
-
 from .apply_mask_to_object_graph import ANY, KEEP, apply_mask_to_object_graph
 from .file_utils import enumerate_lines_from_file, open_file_based_on_extension
 from .temp_helpers import (

--- a/tests/test_process_image_bits.py
+++ b/tests/test_process_image_bits.py
@@ -54,7 +54,7 @@ class TestAPI(BaseDB):
         delete_all_by_ott(db, "images_by_ott", ott)
         test_row = [ott, 20, -3, "foo.jpg", 24000, "Unknown", "cc0 (...)", 0, 0, 0, 0, 0, 0]
         sql = self.set_sql.format(ph)
-        db.executesql(sql, [*test_row, datetime.datetime.now()])
+        db.executesql(sql, [*test_row, datetime.datetime.now().isoformat()])
         made_changes = process_image_bits.resolve(db, ott)
         assert made_changes
         sql = self.get_sql.format(ph)
@@ -87,7 +87,7 @@ class TestAPI(BaseDB):
         r.append([ott, 20, -95, "F.jpg", 35000, "Unknown", "cc0 (...)", 0, 0, 0, 0, 0, 0])
         sql = self.set_sql.format(ph)
         for row in r:
-            db.executesql(sql, [*row, datetime.datetime.now()])
+            db.executesql(sql, [*row, datetime.datetime.now().isoformat()])
         made_changes = process_image_bits.resolve(db, ott)
         assert made_changes
         sql = self.get_sql.format(ph)
@@ -164,7 +164,7 @@ class TestCLI(BaseDB):
         # Insert all the test rows
         ph = placeholder(db)
         for test_row in test_rows:
-            db._adapter.execute(self.set_sql.format(ph), [*test_row, datetime.datetime.now()])
+            db._adapter.execute(self.set_sql.format(ph), [*test_row, datetime.datetime.now().isoformat()])
         db.commit()
 
         # Run the function and make sure it made changes


### PR DESCRIPTION
This makes it easier to run the scripts  from a GitHub install without necessarily having to install the package.

Also use isoformat to avoid test warnings on Py3.12