### PR TITLE
dvc: Don't track data/js_output, always regenerate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,7 @@ jobs:
           [ -n "${{ secrets.DVC_SECRET_ACCESS_KEY }}" ] || { echo "DVC_SECRET_ACCESS_KEY secret is not set"; exit 1; }
           dvc remote modify onezoom-r2 access_key_id ${{ secrets.DVC_ACCESS_KEY_ID }}
           dvc remote modify onezoom-r2 secret_access_key ${{ secrets.DVC_SECRET_ACCESS_KEY }}
+          dvc freeze make_js_treefiles
           dvc repro --allow-missing --dry | tee /dev/stderr | grep -q "Data and pipelines are up to date."
           if dvc data status --not-in-remote | grep -q "Not in remote"; then exit 1; fi
   test:

--- a/dvc.lock
+++ b/dvc.lock
@@ -262,12 +262,6 @@ stages:
       md5: 81dfa9c3747bbe94c57161cc8e22d5c9.dir
       size: 1158499655
       nfiles: 7
-    outs:
-    - path: data/js_output/
-      hash: md5
-      md5: 9782411b79a64d6da09afacae2f3f047.dir
-      size: 8297912
-      nfiles: 6
   discover_latest_wikidata_dump_url:
     cmd: discover_latest_wikidata_dump_url > 
       data/Wiki/wd_JSON/latest-all-json-bz2-url.txt

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -197,5 +197,4 @@ stages:
       - make_js_treefiles --outdir data/js_output
     deps:
       - data/output_files/
-    outs:
-      - data/js_output/
+    always_changed: true


### PR DESCRIPTION
The .gz files in data/js_output/ aren't stable, so we can't use them in as part of a pipeline, as we'll constantly regenerate and upload new ones.

Instead, mark the stage as always_changed, meaning it'll get re-run even on repro --pull.

Fixes #126 