### PR TITLE
Split the DVC status check into its own privileged job

### DIFF
--- a/.github/workflows/dvc.yml
+++ b/.github/workflows/dvc.yml
@@ -1,0 +1,49 @@
+name: DVC
+
+on:
+  pull_request_target:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dvc:
+    name: DVC
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install '.[dev]'
+      - name: Checkout merge ref
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v7
+        with:
+          # Caution: pulling untrusted code into a priveleged pull_request_target environment
+          allow-unsafe-pr-checkout: true
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - name: Pin DVC remote config to base branch
+        # Use the trusted base branch's .dvc/config so a PR can't e.g. send creds to another remote
+        if: github.event_name == 'pull_request_target'
+        run: git show ${{ github.event.pull_request.base.sha }}:.dvc/config > .dvc/config
+      - name: Check DVC status
+        # Note the --dry is important here! Without it, we're running untrusted dvc stages
+        run: |
+          [ -n "${{ secrets.DVC_READONLY_ACCESS_KEY_ID }}" ] || { echo "DVC_READONLY_ACCESS_KEY_ID secret is not set"; exit 1; }
+          [ -n "${{ secrets.DVC_READONLY_SECRET_ACCESS_KEY }}" ] || { echo "DVC_READONLY_SECRET_ACCESS_KEY secret is not set"; exit 1; }
+          dvc remote modify onezoom-r2 access_key_id ${{ secrets.DVC_READONLY_ACCESS_KEY_ID }}
+          dvc remote modify onezoom-r2 secret_access_key ${{ secrets.DVC_READONLY_SECRET_ACCESS_KEY }}
+          dvc freeze make_js_treefiles
+          dvc repro --allow-missing --dry | tee /dev/stderr | grep -q "Data and pipelines are up to date."
+          if dvc data status --not-in-remote | grep -q "Not in remote"; then exit 1; fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,32 +20,6 @@ jobs:
           python-version: "3.10"
       - uses: pre-commit/action@v3.0.0
 
-  dvc:
-    name: DVC
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install '.[dev]'
-      - name: Check DVC status
-        run: |
-          [ -n "${{ secrets.DVC_ACCESS_KEY_ID }}" ] || { echo "DVC_ACCESS_KEY_ID secret is not set"; exit 1; }
-          [ -n "${{ secrets.DVC_SECRET_ACCESS_KEY }}" ] || { echo "DVC_SECRET_ACCESS_KEY secret is not set"; exit 1; }
-          dvc remote modify onezoom-r2 access_key_id ${{ secrets.DVC_ACCESS_KEY_ID }}
-          dvc remote modify onezoom-r2 secret_access_key ${{ secrets.DVC_SECRET_ACCESS_KEY }}
-          dvc freeze make_js_treefiles
-          dvc repro --allow-missing --dry | tee /dev/stderr | grep -q "Data and pipelines are up to date."
-          if dvc data status --not-in-remote | grep -q "Not in remote"; then exit 1; fi
   test:
     name: Python
     runs-on: ubuntu-latest


### PR DESCRIPTION
Jobs that run on 'pull_request' run on the tentative merged result of the pull request and with no access to the github secrets.
The DVC status check requires access to the secrets so that it has read access to the DVC remote.
An alternative to 'pull_request' is 'pull_request_target' where it just runs on the base branch that the PR wants to merge into with none of the untrusted code from the PR itself, but it gets access to the secrets.
There's a security risk that if you choose to checkout the untrusted code in that job, you could end up _running_ untrusted code in your privileged environment.
https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target#the-risks-of-the-pull_request_target-event

Here, that is what I've chosen to do, being careful to not run the untrusted code. For caution, in case there's a way for this to run untrusted code that I'm not seeing, I've used readonly keys.

An alternative considered was that we simply require all PRs to come from within the repo. 
The pull_request_target approach has the benefit that if you're not actually regenerating pipeline files or touching the dvc.lock file, you can still get your PRs merged without us giving you full push access to the repo.

Closes #134 